### PR TITLE
delete default now() of createtime

### DIFF
--- a/spider163/utils/pysql.py
+++ b/spider163/utils/pysql.py
@@ -26,7 +26,7 @@ class Playlist163(Base):
     description = Column(MEDIUMTEXT)
     tags = Column(String(255), server_default="")
     dsc = Column(String(255), server_default="No Description")
-    create_time = Column(TIMESTAMP, server_default=func.now())
+    create_time = Column(TIMESTAMP)
     update_time = Column(TIMESTAMP, server_default=func.now())
     done = Column(String(255), server_default="N")
     done_link = Index("done_link", done, link)
@@ -41,7 +41,7 @@ class Music163(Base):
     playTime = Column(Integer(), server_default="-1") # 歌曲播放次数
     done = Column(String(255), server_default="N")
     has_lyric = Column(String(255), server_default="N")
-    create_time = Column(TIMESTAMP, server_default=func.now())
+    create_time = Column(TIMESTAMP)
     update_time = Column(TIMESTAMP, server_default=func.now())
     comment = Column(Integer(), server_default="-1")
     done_id = Index("done_id", done,id)


### PR DESCRIPTION
 cause mariadb(centos7 version) is not support two columns default value are now() in a table